### PR TITLE
Add Java Package

### DIFF
--- a/build/root/install.sh
+++ b/build/root/install.sh
@@ -55,7 +55,7 @@ fi
 ####
 
 # define aur packages
-aur_packages="ffmpeg-headless makemkv"
+aur_packages="ffmpeg-headless jdk14-openjdk makemkv"
 
 # unable to build ccextractor at this time due to incompatability with ffmpeg 5
 # see open issue:- https://github.com/CCExtractor/ccextractor/issues/1418


### PR DESCRIPTION
I noticed that java wasn't included for some reason in the makemkv container.  Java helps with blu-ray menus on some disks.  What it looks like to me is that the makemkv package is supposed to be installing java as a dependency, but the build script is automatically selecting the first option, which alphabetically is jdk-arm.  This will not work on x86-64 systems, but probably does on ARM systems.  I've not been able to test this on an ARM system, but this does make the java package available on x86-64 systems, which fixes the missing menu info on blu-rays.